### PR TITLE
Adding PCL workflows for PPS

### DIFF
--- a/alcaval_steps.py
+++ b/alcaval_steps.py
@@ -231,7 +231,11 @@ steps['HARVEST_CRAFT23_v1'] = merge([ {'--scenario':'cosmics',
 				'--customise': 'Configuration/DataProcessing/RecoTLR.customiseCosmicData',
 				}, steps['HARVESTDefault'] ])
 #---------------------------------------------------------------------------------------------------
-# PPS JUNE 2023
+
+# PPS PCL Workflows
+
+steps['RunRawPPS2023D']={'INPUT':InputInfo(dataSet='/AlCaPPS/Run2023D-v1/RAW',ls={370293: [[1, 100]]})}
+
 steps['TIER0EXPPPSCALRUN3']={'-s':'RAW2DIGI,L1Reco,ALCAPRODUCER:PPSCalMaxTracks,ENDJOB',
                           '-n':1000,
                           '--process':'ALCARECO',
@@ -241,9 +245,11 @@ steps['TIER0EXPPPSCALRUN3']={'-s':'RAW2DIGI,L1Reco,ALCAPRODUCER:PPSCalMaxTracks,
                           '--data': '',
                           '--datatier':'ALCARECO',
                           '--eventcontent':'ALCARECO',
+                          '--no_exec' : '',
+                          '--customise_commands':'"process.ctppsRawToDigiTaskAlCaRecoProducer = cms.Task(process.ctppsDiamondRawToDigiAlCaRecoProducer, process.totemTimingRawToDigiAlCaRecoProducer, process.ctppsPixelDigisAlCaRecoProducer)"' # disable gtStage2DigisAlCaRecoProducer as 2022 data used in this workflow doesn't have necessary products
                           }
-steps['ALCASPLITPPSCALRUN3']={'-s':'ALCAOUTPUT:PPSCalMaxTracks,ALCA:PromptCalibProdPPSTimingCalib',
-			 '-n':1000,
+
+steps['ALCASPLITPPSCALSAMPIC']={'-s':'ALCAOUTPUT:PPSCalMaxTracks,ALCA:PromptCalibProdPPSDiamondSampic',
                         '--scenario':'pp',
                         '--data':'',
                         '--era':'Run3',
@@ -251,6 +257,40 @@ steps['ALCASPLITPPSCALRUN3']={'-s':'ALCAOUTPUT:PPSCalMaxTracks,ALCA:PromptCalibP
                         '--eventcontent':'ALCARECO',
                         '--conditions':'auto:run3_data_express',
                         '--triggerResultsProcess':'ALCARECO',
+                        '--no_exec' : ''
+                        }
+
+steps['ALCASPLITPPSCALRUN3']={'-s':'ALCAOUTPUT:PPSCalMaxTracks,ALCA:PromptCalibProdPPSTimingCalib',
+                         '-n':1000,
+                        '--scenario':'pp',
+                        '--data':'',
+                        '--era':'Run3',
+                        '--datatier':'ALCARECO',
+                        '--eventcontent':'ALCARECO',
+                        '--conditions':'auto:run3_data_express',
+                        '--triggerResultsProcess':'ALCARECO',
+                        '--no_exec':''
+                        }
+
+steps['ALCASPLITPPSALIGRUN3']={'-s':'ALCAOUTPUT:PPSCalMaxTracks,ALCA:PromptCalibProdPPSAlignment',
+                           '-n':1000,
+                           '--scenario':'pp',
+                           '--data':'',
+                           '--era':'Run3',
+                           '--datatier':'ALCARECO',
+                           '--eventcontent':'ALCARECO',
+                           '--conditions':'auto:run3_data_express',
+                           '--triggerResultsProcess':'ALCARECO',
+                           '--no_exec':''
+                           }
+
+steps['ALCAHARVDPPSCALSAMPIC']={'-s':'ALCAHARVEST:PPSDiamondSampicTimingCalibration',
+                        '--conditions':'auto:run3_data_express',
+                        '--scenario':'pp',
+                        '--data':'',
+                        '--era':'Run3',
+                        '--no_exec' : '',
+                        '--filein':'file:ALCARECOStreamPromptCalibProdPPSDiamondSampic.root'
                         }
 
 steps['ALCAHARVDPPSCALRUN3']={'-s':'ALCAHARVEST:PPSTimingCalibration',
@@ -258,5 +298,16 @@ steps['ALCAHARVDPPSCALRUN3']={'-s':'ALCAHARVEST:PPSTimingCalibration',
                         '--scenario':'pp',
                         '--data':'',
                         '--era':'Run3',
+                        '--no_exec' : '',
                         '--filein':'file:ALCARECOStreamPromptCalibProdPPSTimingCalib.root'}
-#---------------------------------------------------------------------------------------------------
+
+
+steps['ALCAHARVDPPSALIGRUN3']={'-s':'ALCAHARVEST:PPSAlignment',
+                           '--conditions':'auto:run3_data_express',
+                           '--scenario':'pp',
+                           '--data':'',
+                           '--era':'Run3',
+                           '--no_exec' : '',
+                           '--filein':'file:PromptCalibProdPPSAlignment.root'}
+
+

--- a/relval_alca.py
+++ b/relval_alca.py
@@ -127,3 +127,10 @@ workflows[6.56] = ['',['Cosmics2023_v1','TIER0EXPPPSCALRUN3','ALCASPLITPPSCALRUN
 # HI 2023
 workflows[6.57] = ['',['HIRawPrime2023','HLT_HI2023','RECO_HI2023','HARVEST_HI2023']]
 workflows[6.58] = ['',['HIRawPrime2023','RECO_HI2023','HARVEST_HI2023']]
+
+#----------------------------------------------------------------------------------------------------------------
+# PPS PCL Workflows
+workflows[6.62] = ['',['RunRawPPS2023D','TIER0EXPPPSCALRUN3','ALCASPLITPPSCALSAMPIC','ALCAHARVDPPSCALSAMPIC']]  # same as the official workflow 1043
+workflows[6.64] = ['',['RunRawPPS2023D','TIER0EXPPPSCALRUN3','ALCASPLITPPSCALRUN3','ALCAHARVDPPSCALRUN3']]      # same as the official workflow 1044
+workflows[6.66] = ['',['RunRawPPS2023D','TIER0EXPPPSCALRUN3','ALCASPLITPPSALIGRUN3','ALCAHARVDPPSALIGRUN3']]    # same as the official workflow 1045
+


### PR DESCRIPTION
This PR introduces new workflows `6.62`, `6.64` and `6.66` to be used by the AlCaVal tool. These workflows correspond to the central workflows `1043`, `1044` and `1045`, respectively, defined in [1], which are used by various PPS PCLs. 

**PR validation**

- Successfully ran `run_the_matrix_alca.py -l 6.62 -w alca`, `run_the_matrix_alca.py -l 6.64 -w alca` and `run_the_matrix_alca.py -l 6.66 -w alca`
- Tested the cmsDriver commands locally in lxplus successfully

[1] https://github.com/cms-sw/cmssw/blob/master/Configuration/PyReleaseValidation/python/relval_production.py