### PR TITLE
Update L1T emulation option in alcaval_steps.py

### DIFF
--- a/alcaval_steps.py
+++ b/alcaval_steps.py
@@ -26,7 +26,7 @@ steps['HIRawPrime2023']={'INPUT':InputInfo(dataSet='/HIPhysicsRawPrime0/HIRun202
 
 # Step2 HLT: for run3
 step2Defaults = {'--process':'reHLT',
-                      '-s':'L1REPACK,HLT',
+                      '-s':'L1REPACK:Full,HLT',
                       '--conditions':'auto:run3_data',
                       '--data':'',
                       '--eventcontent': 'FEVTDEBUGHLT',
@@ -55,7 +55,7 @@ steps['HLT_CRAFT22_v2'] = merge( [ {'--scenario': 'cosmics', '--datatier': 'FEVT
 				}, step2Defaults] )
 
 # HI
-steps['HLT_HI2023'] = merge( [ {'-s':'L1REPACK,HLT:HIon',
+steps['HLT_HI2023'] = merge( [ {'-s':'L1REPACK:Full,HLT:HIon',
                                 '--conditions':'auto:run3_hlt_HIon',
                                 '--era' : 'Run3_pp_on_PbPb_approxSiStripClusters_2023',
                                 '--customise' : 'HLTrigger/Configuration/CustomConfigs.customiseL1THLTforHIonRepackedRAWPrime'


### PR DESCRIPTION
This PR aims to update the L1 Trigger emulation method used in step 2 of HLT workflows. According to information received from TSG, `L1REPACK` corresponds to `L1REPACK:GT`, which is not appropriate for Run 3 as `GT` refers to pre-2016 L1T. It is instead recommended to use `L1REPACK:Full`. 

The needed changes have been made in this PR to make  `L1REPACK:Full` the default option in the AlCaVal tool.